### PR TITLE
Finally get CarrierWave Direct working

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem 'poltergeist'
 gem 'pundit'
 gem 'rails', '4.2.0'
 gem 'redcarpet'
+gem 'redis-rails'
 gem 'rmagick'
 gem 'sass-rails', '~> 5.0'
 gem 'sdoc', '~> 0.4.0', group: :doc

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,7 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 gem 'sidekiq'
 gem 'turbolinks'
 gem 'uglifier', '>= 1.3.0'
+gem 'unicorn'
 
 group :development, :test do
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -324,8 +324,24 @@ GEM
     rdoc (4.2.0)
     redcarpet (3.2.2)
     redis (3.2.1)
+    redis-actionpack (4.0.0)
+      actionpack (~> 4)
+      redis-rack (~> 1.5.0)
+      redis-store (~> 1.1.0)
+    redis-activesupport (4.0.0)
+      activesupport (~> 4)
+      redis-store (~> 1.1.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-rack (1.5.0)
+      rack (~> 1.5)
+      redis-store (~> 1.1.0)
+    redis-rails (4.0.0)
+      redis-actionpack (~> 4)
+      redis-activesupport (~> 4)
+      redis-store (~> 1.1.0)
+    redis-store (1.1.4)
+      redis (>= 2.2)
     responders (2.1.0)
       railties (>= 4.2.0, < 5)
     rest-client (1.7.3)
@@ -427,6 +443,7 @@ DEPENDENCIES
   rails (= 4.2.0)
   rails_12factor
   redcarpet
+  redis-rails
   rmagick
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -214,6 +214,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.2)
+    kgio (2.9.3)
     launchy (2.4.3)
       addressable (~> 2.3)
     listen (2.9.0)
@@ -317,6 +318,7 @@ GEM
       activesupport (= 4.2.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
+    raindrops (0.13.0)
     rake (10.4.2)
     rb-fsevent (0.9.4)
     rb-inotify (0.9.5)
@@ -398,6 +400,10 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
+    unicorn (4.8.3)
+      kgio (~> 2.6)
+      rack
+      raindrops (~> 0.7)
     uuidtools (2.1.5)
     warden (1.2.3)
       rack (>= 1.0)
@@ -453,4 +459,5 @@ DEPENDENCIES
   sqlite3
   turbolinks
   uglifier (>= 1.3.0)
+  unicorn
   web-console (~> 2.0)

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec unicorn -p $PORT -E $RACK_ENV -c ./config/unicorn.rb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_store = :redis_store, 'redis://redistogo:225db16ed70ba6036a989c4ccaecb381@angelfish.redistogo.com:11265/'
+  config.cache_store = :redis_store, ENV["REDISTOGO_URL"]
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,7 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
-  config.cache_store = :redis_store, ENV['REDISTOGO_URL']
+  config.cache_store = :redis_store, 'redis://redistogo:225db16ed70ba6036a989c4ccaecb381@angelfish.redistogo.com:11265/'
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,6 +1,7 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 
+  config.cache_store = :redis_store, ENV['REDISTOGO_URL']
   # Code is not reloaded between requests.
   config.cache_classes = true
 

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,0 +1,13 @@
+before_fork do |server, worker|
+   @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
+end
+
+worker_processes 3
+after_fork do |server, worker|
+  Sidekiq.configure_client do |config|
+    config.redis = { :size => 1 }
+  end
+  Sidekiq.configure_server do |config|
+    config.redis = { :size => 5 }
+  end
+end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -3,8 +3,6 @@ timeout 15
 preload_app true
 
 before_fork do |server, worker|
-  @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
-
   Signal.trap 'TERM' do
     puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
     Process.kill 'QUIT', Process.pid
@@ -12,20 +10,22 @@ before_fork do |server, worker|
 
   defined?(ActiveRecord::Base) and
     ActiveRecord::Base.connection.disconnect!
+
+  @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
 end
 
 after_fork do |server, worker|
-  Sidekiq.configure_client do |config|
-    config.redis = { :size => 1 }
-  end
-  Sidekiq.configure_server do |config|
-    config.redis = { :size => 5 }
-  end
-
   Signal.trap 'TERM' do
     puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
   end
 
   defined?(ActiveRecord::Base) and
     ActiveRecord::Base.establish_connection
+
+  Sidekiq.configure_client do |config|
+    config.redis = { :size => 1 }
+  end
+  Sidekiq.configure_server do |config|
+    config.redis = { :size => 5 }
+  end
 end

--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -1,8 +1,19 @@
+worker_processes Integer(ENV["WEB_CONCURRENCY"] || 3)
+timeout 15
+preload_app true
+
 before_fork do |server, worker|
-   @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
+  @sidekiq_pid ||= spawn("bundle exec sidekiq -c 2")
+
+  Signal.trap 'TERM' do
+    puts 'Unicorn master intercepting TERM and sending myself QUIT instead'
+    Process.kill 'QUIT', Process.pid
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.connection.disconnect!
 end
 
-worker_processes 3
 after_fork do |server, worker|
   Sidekiq.configure_client do |config|
     config.redis = { :size => 1 }
@@ -10,4 +21,11 @@ after_fork do |server, worker|
   Sidekiq.configure_server do |config|
     config.redis = { :size => 5 }
   end
+
+  Signal.trap 'TERM' do
+    puts 'Unicorn worker intercepting TERM and doing nothing. Wait for master to send QUIT'
+  end
+
+  defined?(ActiveRecord::Base) and
+    ActiveRecord::Base.establish_connection
 end


### PR DESCRIPTION
CarrierWave direct now works with Redis To Go and Sidekiq. Instead of running extra worker dynos on Heroku, it uses the Unicorn web server to split up the one web dyno.
